### PR TITLE
Fix #4: make buildable on Mac OS / with Clang

### DIFF
--- a/include/okapi/api/units/RQuantityName.hpp
+++ b/include/okapi/api/units/RQuantityName.hpp
@@ -2,6 +2,7 @@
 #include "okapi/api/units/QLength.hpp"
 #include "okapi/api/units/QSpeed.hpp"
 #include <stdexcept>
+#include <string>
 #include <typeindex>
 #include <unordered_map>
 

--- a/include/test/tests/api/implMocks.hpp
+++ b/include/test/tests/api/implMocks.hpp
@@ -251,7 +251,7 @@ class MockTimer : public AbstractTimer {
 
   QTime millis() const override;
 
-  std::chrono::system_clock::time_point epoch = std::chrono::high_resolution_clock::from_time_t(0);
+  std::chrono::system_clock::time_point epoch = std::chrono::system_clock::from_time_t(0);
 };
 
 /**

--- a/src/api/chassis/controller/defaultOdomChassisController.cpp
+++ b/src/api/chassis/controller/defaultOdomChassisController.cpp
@@ -39,7 +39,9 @@ void DefaultOdomChassisController::driveToPoint(const Point &ipoint,
                                                 const QLength &ioffset) {
   waitForOdomTask();
 
-  auto [length, angle] = OdomMath::computeDistanceAndAngleToPoint(
+  QLength length;
+  QAngle angle;
+  std::tie<QLength, QAngle>(length, angle) = OdomMath::computeDistanceAndAngleToPoint(
     ipoint.inFT(defaultStateMode), odom->getState(StateMode::FRAME_TRANSFORMATION));
 
   if (ibackwards) {

--- a/test/implMocks.cpp
+++ b/test/implMocks.cpp
@@ -192,7 +192,7 @@ MockTimer::MockTimer() : AbstractTimer(millis()) {
 
 QTime MockTimer::millis() const {
   return std::chrono::duration_cast<std::chrono::milliseconds>(
-           std::chrono::high_resolution_clock::now() - epoch)
+           std::chrono::system_clock::now() - epoch)
            .count() *
          millisecond;
 }


### PR DESCRIPTION
OkapiLib did not build on all systems due to not-officially-supported idioms and by referencing some attributes of high_resolution_clock.

### Description of the Change

Makes OkapiLib buildable with Clang / on Mac OS

### Motivation

Make contributing to the project more accessible.

### Possible Drawbacks

The Workflow build is unaffected.

Switching from `std::chrono::high_resolution_clock` to `system_clock` may have different behavior on the V5 brain than on a typical computer.

### Verification Process

Library now builds without errors.

GitHub workflow `test` is still successful at building the code

### Applicable Issues

#4 
