### PR TITLE
Fix #8: Update LoggerTests

### DIFF
--- a/test/loggerTests.cpp
+++ b/test/loggerTests.cpp
@@ -43,16 +43,13 @@ TEST_F(LoggerTest, OffLevel) {
     std::make_unique<ConstantMockTimer>(0_ms), logFile, Logger::LogLevel::off);
 
   logData(logger);
-  fputs("EMPTY_FILE", logFile);
   rewind(logFile);
 
   char *line = nullptr;
   size_t len;
 
-  fputs("EMPTY_FILE", logFile);
-
-  getline(&line, &len, logFile);
-  EXPECT_STREQ(line, "EMPTY_FILE");
+  // Check that we are done reading
+  EXPECT_EQ(getline(&line, &len, logFile), EOF);
 
   if (line) {
     free(line);
@@ -72,6 +69,8 @@ TEST_F(LoggerTest, ErrorLevel) {
   getline(&line, &len, logFile);
   std::string expected = "0 (" + CrossplatformThread::getName() + ") ERROR: MSG\n";
   EXPECT_STREQ(line, expected.c_str());
+
+  EXPECT_EQ(getline(&line, &len, logFile), EOF);
 
   if (line) {
     free(line);
@@ -95,6 +94,8 @@ TEST_F(LoggerTest, WarningLevel) {
   getline(&line, &len, logFile);
   expected = "0 (" + CrossplatformThread::getName() + ") WARN: MSG\n";
   EXPECT_STREQ(line, expected.c_str());
+
+  EXPECT_EQ(getline(&line, &len, logFile), EOF);
 
   if (line) {
     free(line);
@@ -122,6 +123,8 @@ TEST_F(LoggerTest, InfoLevel) {
   getline(&line, &len, logFile);
   expected = "0 (" + CrossplatformThread::getName() + ") INFO: MSG\n";
   EXPECT_STREQ(line, expected.c_str());
+
+  EXPECT_EQ(getline(&line, &len, logFile), EOF);
 
   if (line) {
     free(line);
@@ -153,6 +156,8 @@ TEST_F(LoggerTest, DebugLevel) {
   getline(&line, &len, logFile);
   expected = "0 (" + CrossplatformThread::getName() + ") DEBUG: MSG\n";
   EXPECT_STREQ(line, expected.c_str());
+
+  EXPECT_EQ(getline(&line, &len, logFile), EOF);
 
   if (line) {
     free(line);

--- a/test/loggerTests.cpp
+++ b/test/loggerTests.cpp
@@ -165,22 +165,23 @@ TEST_F(LoggerTest, DebugLevel) {
 }
 
 TEST_F(LoggerTest, TestLazyLogging) {
-  rewind(logFile);
   logger = std::make_shared<Logger>(
-    std::make_unique<ConstantMockTimer>(0_ms), logFile, Logger::LogLevel::info);
+    std::make_unique<ConstantMockTimer>(0_ms), logFile, Logger::LogLevel::debug);
 
-  int x = 0;
-  logger->debug([=, &x]() {
-    x++;
-    return std::string("");
+  logger->debug([=]() {
+    return std::string("MSG");
   });
 
-  EXPECT_EQ(x, 0);
+  rewind(logFile);
 
   char *line = nullptr;
   size_t len;
 
   getline(&line, &len, logFile);
+  std::string expected = "0 (" + CrossplatformThread::getName() + ") DEBUG: MSG\n";
+  EXPECT_STREQ(line, expected.c_str());
+
+  EXPECT_EQ(getline(&line, &len, logFile), EOF);
 
   if (line) {
     free(line);

--- a/test/loggerTests.cpp
+++ b/test/loggerTests.cpp
@@ -23,6 +23,7 @@ class LoggerTest : public ::testing::Test {
     if (logger) {
       logger->close();
     }
+    delete[] logBuffer;
   }
 
   void logData(const std::shared_ptr<Logger> &) const {


### PR DESCRIPTION
### Description of the Change

Use an `fmemopen` stream rather than a `open_memstream` stream, as the latter is specified to be write-only.

Also adds new test cases.

### Motivation

The previous tests used a technically write-only stream in memory, which causes the tests to fail on some systems. Instead, we can use an `fmemopen` stream to ensure it is always readable.

The old tests were not comprehensive and may not have detected all issues.

### Possible Drawbacks

None anticipated, unless future tests involve writing more than 10,000 characters.

### Verification Process

Passes all test cases and Valgrind.

### Applicable Issues

#8
