### PR TITLE
Add task notify support to CrossplatformThread

### DIFF
--- a/include/okapi/api/coreProsAPI.hpp
+++ b/include/okapi/api/coreProsAPI.hpp
@@ -92,6 +92,16 @@ class CrossplatformThread {
   }
 #endif
 
+#ifdef THREADS_STD
+  std::uint32_t notify() {
+    return 1;
+  }
+#else
+  std::uint32_t notify() {
+    return pros::c::task_notify(thread);
+  }
+#endif
+
   static std::string getName() {
 #ifdef THREADS_STD
     std::ostringstream ss;


### PR DESCRIPTION
### Description of the Change

Adds notify() to the CrossplatformThread, which does nothing for std::thread and is a wrapper around pros::c::notify_take(task) when a pros task is used

### Motivation

This allows code that uses task notification to be testable locally by preventing having to interface with pros when notify needs to be called.

### Possible Drawbacks

None

### Verification Process

Ran it on the bot .The code should be simple enough too.

### Applicable Issues

N/A